### PR TITLE
Migrate watcher microservice

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,3 @@ gem 'dalli'
 gem 'em-eventsource'
 gem 'simple-rss'
 gem 'rest-client'
-
-gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,7 @@ ruby '2.4.0'
 
 gem 'dalli'
 gem 'em-eventsource'
+gem 'simple-rss'
+gem 'rest-client'
+
+gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 ruby '2.4.0'
 
+gem 'dalli'
 gem 'em-eventsource'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,11 @@ GEM
   specs:
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
+    coderay (1.1.1)
     cookiejar (0.3.3)
     dalli (2.7.6)
+    domain_name (0.5.20170223)
+      unf (>= 0.0.5, < 1.0.0)
     em-eventsource (0.2.1)
       em-http-request (~> 1.0)
       eventmachine (~> 1.0)
@@ -17,8 +20,28 @@ GEM
     em-socksify (0.3.1)
       eventmachine (>= 1.0.0.beta.4)
     eventmachine (1.2.3)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     http_parser.rb (0.6.0)
+    method_source (0.8.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    netrc (0.11.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     public_suffix (2.0.5)
+    rest-client (2.0.1)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    simple-rss (1.3.1)
+    slop (3.6.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
@@ -26,6 +49,9 @@ PLATFORMS
 DEPENDENCIES
   dalli
   em-eventsource
+  pry
+  rest-client
+  simple-rss
 
 RUBY VERSION
    ruby 2.4.0p0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ GEM
   specs:
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
-    coderay (1.1.1)
     cookiejar (0.3.3)
     dalli (2.7.6)
     domain_name (0.5.20170223)
@@ -23,22 +22,16 @@ GEM
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http_parser.rb (0.6.0)
-    method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     netrc (0.11.0)
-    pry (0.10.4)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
     public_suffix (2.0.5)
     rest-client (2.0.1)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     simple-rss (1.3.1)
-    slop (3.6.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.2)
@@ -49,7 +42,6 @@ PLATFORMS
 DEPENDENCIES
   dalli
   em-eventsource
-  pry
   rest-client
   simple-rss
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
     cookiejar (0.3.3)
+    dalli (2.7.6)
     em-eventsource (0.2.1)
       em-http-request (~> 1.0)
       eventmachine (~> 1.0)
@@ -23,6 +24,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  dalli
   em-eventsource
 
 RUBY VERSION

--- a/dispatch.rb
+++ b/dispatch.rb
@@ -214,8 +214,7 @@ end
 EM.run do
   # Watcher
   watcher = Watcher.new(ENV["WATCHER_HOOK_URL"])
-  watcher.call
-  #EventMachine.add_periodic_timer(30) { watcher.call }
+  EventMachine.add_periodic_timer(30) { watcher.call }
 
   # Github event processing
   github = GithubProcessor.new(ENV["GITHUB_HOOK_URL"])

--- a/dispatch.rb
+++ b/dispatch.rb
@@ -201,6 +201,8 @@ class Watcher
   end
 
   def with_rss_names(url, platform, &block)
+    cached_names = @cache.fetch(url) { [] }
+
     request = RestClient.get(url)
     names = SimpleRSS.parse(request.body).entries.map(&:title)
 
@@ -214,10 +216,9 @@ class Watcher
       end
     end
 
-    cached_names = []
     yield (names - cached_names)
 
-    #@cache.set(url, names)
+    @cache.set(url, names)
   end
 end
 

--- a/dispatch.rb
+++ b/dispatch.rb
@@ -92,7 +92,7 @@ end
 
 EM.run do
   # Github event processing
-  github = GithubProcessor.new(ENV["EVENT_HOOK_URL"])
+  github = GithubProcessor.new(ENV["GITHUB_HOOK_URL"])
   source = EM::EventSource.new(ENV["FIREHOSE_URL"])
   source.on "event", &github.method(:process)
   source.error {|e| puts "error #{e}" }

--- a/dispatch.rb
+++ b/dispatch.rb
@@ -90,7 +90,88 @@ class GithubProcessor
   end
 end
 
+class Watcher
+  JSON_SERVICES = [
+    ['http://npm-update-stream.libraries.io/', 'NPM'],
+    ['https://rubygems.org/api/v1/activity/just_updated.json', 'Rubygems'],
+    ['https://rubygems.org/api/v1/activity/latest.json', 'Rubygems'],
+    ['https://atom.io/api/packages?page=1&sort=created_at&direction=desc', 'Atom'],
+    ['https://atom.io/api/packages?page=1&sort=updated_at&direction=desc', 'Atom'],
+    ['http://package.elm-lang.org/new-packages', 'Elm'],
+    ['https://crates.io/summary', 'Cargo'],
+    ['http://api.metacpan.org/v0/release/_search?q=status:latest&fields=distribution&sort=date:desc&size=100', 'CPAN'],
+    ['https://hex.pm/api/packages?sort=inserted_at', 'Hex'],
+    ['https://hex.pm/api/packages?sort=updated_at', 'Hex']
+  ]
+
+  def initialize(url)
+    @sender = EventSender.new(url)
+  end
+
+  def call
+    JSON_SERVICES.each do |service|
+      process(*service, :json)
+    end
+  end
+
+  private
+
+  def process(url, platform, type)
+    with_names(url, platform, type) do |names|
+      names.each do |name|
+        puts "WATCHER: #{platform}/#{name}"
+
+        @sender.send_event(
+          params: { platform: platform, name: name }
+        )
+      end
+    end
+  end
+
+  def with_names(url, platform, type, &block)
+    if type == :json
+      with_json_names(url, platform, &block)
+    end
+  end
+
+  def with_json_names(url, platform, &block)
+    request = EventMachine::HttpRequest.new(url)
+      .get({
+      head: { "User-Agent" => "Libraries.io Watcher" }
+    })
+
+    request.callback do
+      json = JSON.parse(request.response)
+
+      if platform == 'Elm'
+        names = json
+      elsif platform == 'NPM'
+        names = json
+      elsif platform == 'Cargo'
+        updated_names = json['just_updated'].map{|c| c['name']}
+        new_names = json['new_crates'].map{|c| c['name']}
+        names = (updated_names + new_names).uniq
+      elsif platform == 'CPAN'
+        names = json['hits']['hits'].map{|project| project['fields']['distribution'] }.uniq
+      else
+        names = json.map{|g| g['name']}.uniq
+      end
+
+      update_names = []
+
+      yield ((names - update_names))
+
+      #dc.set(url, names)
+    end
+  end
+end
+
 EM.run do
+  # Watcher
+  watcher = Watcher.new(ENV["WATCHER_HOOK_URL"])
+  watcher.call
+  #EventMachine.add_periodic_timer(30) { watcher.call }
+
   # Github event processing
   github = GithubProcessor.new(ENV["GITHUB_HOOK_URL"])
   source = EM::EventSource.new(ENV["FIREHOSE_URL"])

--- a/dispatch.rb
+++ b/dispatch.rb
@@ -104,8 +104,8 @@ class Watcher
     ['http://package.elm-lang.org/new-packages', 'Elm'],
     ['https://crates.io/summary', 'Cargo'],
     ['http://api.metacpan.org/v0/release/_search?q=status:latest&fields=distribution&sort=date:desc&size=100', 'CPAN'],
-    #['https://hex.pm/api/packages?sort=inserted_at', 'Hex'],
-    #['https://hex.pm/api/packages?sort=updated_at', 'Hex']
+    ['https://hex.pm/api/packages?sort=inserted_at', 'Hex'],
+    ['https://hex.pm/api/packages?sort=updated_at', 'Hex']
   ]
 
   MEMCACHED_OPTIONS = {
@@ -164,7 +164,12 @@ class Watcher
   def with_names(url, platform, type, &block)
     cached_names = @cache.fetch(url) { [] }
 
-    request = RestClient.get(url, { "User-Agent" => "Libraries.io Watcher" })
+    begin
+      request = RestClient.get(url, { "User-Agent" => "Libraries.io Watcher" })
+    rescue => e
+      puts "Error: #{url} --> #{e}"
+      return []
+    end
 
     if type == :json
       names = with_json_names(request.body, platform)


### PR DESCRIPTION
This migrates over the `watcher` microservice to `dispatch`. I'd like to try and ditch EventMachine for just bare threads in a followup PR.

cc @andrew 