### PR TITLE
Remove npm processing in favor of depper

### DIFF
--- a/dispatch.rb
+++ b/dispatch.rb
@@ -103,7 +103,6 @@ end
 
 class Watcher
   JSON_SERVICES = [
-    ['http://npm-update-stream.libraries.io/', 'NPM'],
     ['https://atom.io/api/packages?page=1&sort=created_at&direction=desc', 'Atom'],
     ['https://atom.io/api/packages?page=1&sort=updated_at&direction=desc', 'Atom'],
     ['http://package.elm-lang.org/new-packages', 'Elm'],
@@ -191,8 +190,6 @@ class Watcher
     json = JSON.parse(request_body)
 
     if platform == 'Elm'
-      names = json
-    elsif platform == 'NPM'
       names = json
     elsif platform == 'Cargo'
       updated_names = json['just_updated'].map{|c| c['name']}


### PR DESCRIPTION
Things are looking good on Depper. Shall we?!

```
2021/01/12 20:06:51 Depper Publishing platform=npm name=react-slippi-visualiser version=0.1.13
2021/01/12 20:06:51 Depper Publishing platform=npm name=gatsby-plugin-imgix version=0.9.0
2021/01/12 20:07:01 Depper Publishing platform=npm name=@fluencelabs/aquamarine-stepper version=0.0.8-refactor-errors.3
2021/01/12 20:07:07 Depper Publishing platform=npm name=fieldz version=0.2.13
2021/01/12 20:07:09 Depper Publishing platform=npm name=lamassu-configs version=1.0.0
2021/01/12 20:07:12 Depper Publishing platform=npm name=@copart/angular-components version=0.5.6
2021/01/12 20:07:25 Depper Publishing platform=npm name=@unexp/router version=0.0.18
2021/01/12 20:07:30 Depper Publishing platform=npm name=staff-code version=1.0.122
2021/01/12 20:07:30 Depper Publishing platform=npm name=vite-plugin-multi-device version=0.0.3
```